### PR TITLE
fix thor warning

### DIFF
--- a/lib/ec2ssh/cli.rb
+++ b/lib/ec2ssh/cli.rb
@@ -61,8 +61,10 @@ Set environment variables to access AWS such as:
     end
 
     [:red,:green,:yellow].each do |col|
-      define_method(col) do |str|
-        puts hl.color(str, col)
+      no_tasks do
+        define_method(col) do |str|
+          puts hl.color(str, col)
+        end
       end
     end
   end


### PR DESCRIPTION
When execute ec2ssh command, thor gives  following warnings.

```
[WARNING] Attempted to create task "red" without usage or description. Call desc if you want this method to be available as task or declare it inside a no_tasks{} block. Invoked from "/Users/yuki_ito/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/ec2ssh-1.0.2/lib/ec2ssh/cli.rb:64:in `define_method'".
[WARNING] Attempted to create task "green" without usage or description. Call desc if you want this method to be available as task or declare it inside a no_tasks{} block. Invoked from "/Users/yuki_ito/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/ec2ssh-1.0.2/lib/ec2ssh/cli.rb:64:in `define_method'".
[WARNING] Attempted to create task "yellow" without usage or description. Call desc if you want this method to be available as task or declare it inside a no_tasks{} block. Invoked from "/Users/yuki_ito/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/ec2ssh-1.0.2/lib/ec2ssh/cli.rb:64:in `define_method'".
```
