### PR TITLE
Add ssh_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ Updates ssh_config by 'my_key1' aws key:
 $ ec2ssh update --aws-key my_key1
 ```
 
+## ssh options
+You can set other ssh options such as IdentityFile or User.
+
+```
+$ cat ~/.ec2ssh
+---
+path: /home/yourname/.ssh/config
+aws_keys:
+  default:
+    access_key_id: ...
+    secret_access_key: ...
+  my_key1:
+    access_key_id: ...
+    secret_access_key: ...
+regions:
+  - ap-northeast-1
+ssh_options:
+  - "IdentityFile ~/.ssh/ec2.id_rsa"
+  - "User ec2-user"
+  - "TCPKeepAlive yes"
+```
+
 # How to upgrade from 1.x to 2.x
 If you have used ec2ssh-1.x, it seems that you may not have '~/.ec2ssh'.
 So you need execute `ec2ssh init` once to create `~/.ec2ssh`, and edit it as you like.

--- a/lib/ec2ssh/cli.rb
+++ b/lib/ec2ssh/cli.rb
@@ -83,10 +83,23 @@ module Ec2ssh
       end
 
       def merge_sections(config)
-        section_str = hosts.map { |h| <<-END }.join
+        ssh_options = dotfile['ssh_options']
+
+        section_str = hosts.map { |h|
+          section = <<-END
 Host #{h[:host]}
   HostName #{h[:dns_name]}
-        END
+          END
+
+          unless ssh_options.nil?
+            ssh_options.each {|line|
+              section << "  #{line}\n"
+            }
+          end
+
+          section
+        }.join
+
         config.sections[options.aws_key] ||= SshConfig::Section.new(
           options.aws_key,
           section_str


### PR DESCRIPTION
This change allows users to add any SSH options such as IdentityFile or User.
I think most of users need to set User on EC2 at least.
