### PR TITLE
change thor version specifier from 0.14.6 to 0.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    ec2ssh (2.0.3)
+    ec2ssh (2.0.5)
       aws-sdk (~> 1.8)
       highline (~> 1.6)
-      thor (~> 0.14.6)
+      thor (~> 0.14)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.2)
-    aws-sdk (1.8.5)
+    aws-sdk (1.10.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
@@ -26,8 +26,8 @@ GEM
     guard-rspec (2.4.0)
       guard (>= 1.1)
       rspec (~> 2.11)
-    highline (1.6.17)
-    json (1.7.7)
+    highline (1.6.19)
+    json (1.8.0)
     listen (0.7.2)
     lumberjack (1.0.2)
     method_source (0.8.1)
@@ -49,7 +49,7 @@ GEM
     terminal-table (1.4.5)
     thor (0.14.6)
     timecop (0.5.9.1)
-    uuidtools (2.1.3)
+    uuidtools (2.1.4)
     webmock (1.9.0)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)

--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{ec2ssh is a ssh_config manager for AWS EC2}
 
   s.rubyforge_project = "ec2ssh"
-  s.add_dependency "thor", "~> 0.14.6"
+  s.add_dependency "thor", "~> 0.14"
   s.add_dependency "highline", "~> 1.6"
   s.add_dependency 'aws-sdk', '~> 1.8'
 


### PR DESCRIPTION
now 0.18.1 is the major version of [thor](https://github.com/wycats/thor), so I'd like to allow ec2ssh to use latest version.
