### PR TITLE
Support environment variables in .ec2ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ ssh_options:
   - "TCPKeepAlive yes"
 ```
 
+## environment variables
+You can use environment variables as follows.
+
+```
+$ cat ~/.ec2ssh
+---
+path: /home/yourname/.ssh/config
+aws_keys:
+  default:
+    access_key_id: <%= ENV['AMAZON_ACCESS_KEY_ID'] %>
+    secret_access_key: <%= ENV['AMAZON_SECRET_ACCESS_KEY'] %>
+regions:
+  - ap-northeast-1
+```
+
 # How to upgrade from 1.x to 2.x
 If you have used ec2ssh-1.x, it seems that you may not have '~/.ec2ssh'.
 So you need execute `ec2ssh init` once to create `~/.ec2ssh`, and edit it as you like.

--- a/lib/ec2ssh/dotfile.rb
+++ b/lib/ec2ssh/dotfile.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'yaml'
 
 module Ec2ssh
@@ -17,7 +18,7 @@ module Ec2ssh
     end
 
     def self.load(path)
-      new YAML.load(open(path).read)
+      new YAML.load(ERB.new(open(path).read).result)
     end
 
     def save(path)


### PR DESCRIPTION
Hi!!

This patch allows users to use environment variables in .ec2ssh as follows.

```
$ cat ~/.ec2ssh

---
path: /home/yourname/.ssh/config
aws_keys:
  default:
    access_key_id: <%= ENV['AMAZON_ACCESS_KEY_ID'] %>
    secret_access_key: <%= ENV['AMAZON_SECRET_ACCESS_KEY'] %>
regions:
  - ap-northeast-1
```
