### PR TITLE
Update EC2 API endpoint

### DIFF
--- a/lib/ec2ssh/hosts.rb
+++ b/lib/ec2ssh/hosts.rb
@@ -10,7 +10,7 @@ module Ec2ssh
         key = dotfile.aws_key(keyname)
         raise AwsEnvNotDefined if key['access_key_id'].nil? || key['secret_access_key'].nil?
         h[region] = AWS::EC2.new(
-          :ec2_endpoint      => "#{region}.ec2.amazonaws.com",
+          :ec2_endpoint      => "ec2.#{region}.amazonaws.com",
           :access_key_id     => key['access_key_id'],
           :secret_access_key => key['secret_access_key']
         )


### PR DESCRIPTION
Endpoint seems changed to `ec2.#{region}.amazonaws.com`.

see:
http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region
