### PR TITLE
Fix old EC2 API Endpoint domain declaration.

### DIFF
--- a/lib/ec2ssh/hosts.rb
+++ b/lib/ec2ssh/hosts.rb
@@ -10,7 +10,7 @@ module Ec2ssh
         key = dotfile.aws_key(keyname)
         raise AwsEnvNotDefined if key['access_key_id'].nil? || key['secret_access_key'].nil?
         h[region] = AWS::EC2.new(
-          :ec2_endpoint      => "#{region}.ec2.amazonaws.com",
+          :region            => region,
           :access_key_id     => key['access_key_id'],
           :secret_access_key => key['secret_access_key']
         )


### PR DESCRIPTION
My ec2ssh version v2.0.7.
This pull request fixes region endpoint domain change problem.
This issue related PR #16.

I ran following update command. But get error stack trace.

```
% be ec2ssh update
/Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/aws-sdk-v1-1.57.0/lib/aws/core/client.rb:375:in `return_or_raise': AWS was not able to validate the provided access credentials (AWS::EC2::Errors::AuthFailure)
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/aws-sdk-v1-1.57.0/lib/aws/core/client.rb:476:in `client_request'
        from (eval):3:in `describe_instances'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/aws-sdk-v1-1.57.0/lib/aws/ec2/filtered_collection.rb:44:in `filtered_request'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:38:in `instances'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:28:in `process_region'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:22:in `block in all'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:21:in `map'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:21:in `all'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:62:in `hosts'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:88:in `merge_sections'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:36:in `update'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/bin/ec2ssh:4:in `<top (required)>'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/bin/ec2ssh:23:in `load'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/bin/ec2ssh:23:in `<main>'
```

I displayed variables for suspected error source `hosts.rb`.

```
[wnoguchi@noguchiwataru-no-MacBook-Pro] ~
% vi /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb
[wnoguchi@noguchiwataru-no-MacBook-Pro] ~
% be ec2ssh update
"ap-northeast-1.ec2.amazonaws.com"
/Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:41:in `instances': undefined method `instances' for "F1vuBXby67+UD/83H2w0zbUNX39xRuVBeOGCFts9":String (NoMethodError)
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:31:in `process_region'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:25:in `block in all'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:24:in `map'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/hosts.rb:24:in `all'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:62:in `hosts'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:88:in `merge_sections'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/lib/ec2ssh/cli.rb:36:in `update'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/gems/ec2ssh-2.0.7/bin/ec2ssh:4:in `<top (required)>'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/bin/ec2ssh:23:in `load'
        from /Users/wnoguchi/vendor/bundle/ruby/2.0.0/bin/ec2ssh:23:in `<main>'
```

Endpoint domain has been shown as "ap-northeast-1.ec2.amazonaws.com".
But my AWS CLI describe-regions result shows different endpoint.

```
[wnoguchi@noguchiwataru-no-MacBook-Pro] ~
% aws ec2 describe-regions | jq '.'
{
  "Regions": [
    {
      "Endpoint": "ec2.eu-central-1.amazonaws.com",
      "RegionName": "eu-central-1"
    },
    {
      "Endpoint": "ec2.sa-east-1.amazonaws.com",
      "RegionName": "sa-east-1"
    },
    {
      "Endpoint": "ec2.ap-northeast-1.amazonaws.com",
      "RegionName": "ap-northeast-1"
    },
    {
      "Endpoint": "ec2.eu-west-1.amazonaws.com",
      "RegionName": "eu-west-1"
    },
    {
      "Endpoint": "ec2.us-east-1.amazonaws.com",
      "RegionName": "us-east-1"
    },
    {
      "Endpoint": "ec2.us-west-1.amazonaws.com",
      "RegionName": "us-west-1"
    },
    {
      "Endpoint": "ec2.us-west-2.amazonaws.com",
      "RegionName": "us-west-2"
    },
    {
      "Endpoint": "ec2.ap-southeast-2.amazonaws.com",
      "RegionName": "ap-southeast-2"
    },
    {
      "Endpoint": "ec2.ap-southeast-1.amazonaws.com",
      "RegionName": "ap-southeast-1"
    }
  ]
}
```

My problem fix between PR #16 difference is that point of specifying Region Name only.
I think API Endpoint domain will changed too.
I want to ec2ssh v2.0.8 release for this fix if possible...
