### PR TITLE
Create a ssh_config file if not exists

### DIFF
--- a/lib/ec2ssh/ssh_config.rb
+++ b/lib/ec2ssh/ssh_config.rb
@@ -48,6 +48,10 @@ module Ec2ssh
     end
 
     def config_src
+      unless File.exist?(@path)
+        File.open(@path, "w", 0600).close()
+      end
+
       @config_src ||= File.open(@path, "r") do |f|
         f.read
       end


### PR DESCRIPTION
When `ec2ssh init` is executed without ~/.ssh/config, Errno::ENOENT is raised, so some error handling is needed.
Creating a blank ssh_config file at the beginning of `ec2ssh init` is a reasonable solution, I think. This is convenient when you run `ec2ssh` on newly created EC2 instances, for example.
