### PR TITLE
Ignore unnamed instances

### DIFF
--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -31,6 +31,7 @@ module Ec2ssh
         ec2s[key_name][region].instances.
           filter('instance-state-name', 'running').
           to_a.
+          select {|ins| ins.tags['Name'] }.
           sort_by {|ins| ins.tags['Name'] }
       }.flatten
     end


### PR DESCRIPTION
To fix the following error I encountered after migration to ec2ssh version 3.0.0.

```
$ ec2ssh update
/Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:37:in `sort_by': comparison of NilClass with String failed (ArgumentError)
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:37:in `block in instances'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:30:in `map'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:30:in `instances'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/builder.rb:16:in `block in build_host_lines'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/builder.rb:14:in `each'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/builder.rb:14:in `build_host_lines'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/command/update.rb:20:in `run'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/lib/ec2ssh/cli.rb:28:in `update'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/r7kamura/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ec2ssh-3.0.0/bin/ec2ssh:4:in `<top (required)>'
        from /Users/r7kamura/.rbenv/versions/2.2.0/bin/ec2ssh:23:in `load'
        from /Users/r7kamura/.rbenv/versions/2.2.0/bin/ec2ssh:23:in `<main>'
```