### PR TITLE
Ignore unnamed instances in dotfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ aws_keys(
 )
 regions 'us-east-1'
 
+# Ignore unnamed instances
+reject {|instance| !instance.tags['Name'] }
+
 # You can use methods of AWS::EC2::Instance.
 # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html
 host_line <<END

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -31,7 +31,7 @@ module Ec2ssh
         ec2s[key_name][region].instances.
           filter('instance-state-name', 'running').
           to_a.
-          sort_by {|ins| ins.tags['Name'] }
+          sort_by {|ins| ins.tags['Name'] || '' }
       }.flatten
     end
   end

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -31,7 +31,6 @@ module Ec2ssh
         ec2s[key_name][region].instances.
           filter('instance-state-name', 'running').
           to_a.
-          select {|ins| ins.tags['Name'] }.
           sort_by {|ins| ins.tags['Name'] }
       }.flatten
     end

--- a/lib/ec2ssh/migrator.rb
+++ b/lib/ec2ssh/migrator.rb
@@ -47,6 +47,9 @@ module Ec2ssh
 
       out.puts <<-END
 
+# Ignore unnamed instances
+reject {|instance| !instance.tags['Name'] }
+
 # You can use methods of AWS::EC2::Instance.
 # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html
 host_line <<EOS

--- a/spec/lib/ec2ssh/command/migrate_spec.rb
+++ b/spec/lib/ec2ssh/command/migrate_spec.rb
@@ -48,6 +48,9 @@ aws_keys(
   key1: { access_key_id: 'ACCESS_KEY1', secret_access_key: 'SECRET1' }
 )
 
+# Ignore unnamed instances
+reject {|instance| !instance.tags['Name'] }
+
 # You can use methods of AWS::EC2::Instance.
 # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html
 host_line <<EOS

--- a/spec/lib/ec2ssh/migrator_spec.rb
+++ b/spec/lib/ec2ssh/migrator_spec.rb
@@ -32,6 +32,9 @@ aws_keys(
 )
 regions 'ap-northeast-1', 'us-east-1'
 
+# Ignore unnamed instances
+reject {|instance| !instance.tags['Name'] }
+
 # You can use methods of AWS::EC2::Instance.
 # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html
 host_line <<EOS


### PR DESCRIPTION
Re-implemented with https://github.com/mirakui/ec2ssh/pull/22

It should not ignore unnamed instances in making ec2 instance list because I guess someone want to use ec2ssh with unnamed instances.

I prefer to do it in dotfile (.ec2ssh)