### PR TITLE
Handling instances with empty name.

### DIFF
--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -31,7 +31,7 @@ module Ec2ssh
         ec2s[key_name][region].instances.
           filter('instance-state-name', 'running').
           to_a.
-          sort_by {|ins| ins.tags['Name'] }
+          sort_by {|ins| ins.tags['Name'].to_s }
       }.flatten
     end
   end

--- a/spec/lib/ec2ssh/ec2_instances_spec.rb
+++ b/spec/lib/ec2ssh/ec2_instances_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'ec2ssh/ec2_instances'
+
+describe Ec2ssh::Ec2Instances do
+  describe '#instances' do
+    let(:key_name) {
+      "dummy_key_name"
+    }
+
+    let(:region) {
+      "ap-northeast-1"
+    }
+
+    let(:mock) do
+      described_class.new(aws_keys='', regions=[region]).tap do |e|
+        allow(e).to receive(:ec2s) { ec2s }
+        allow(e).to receive(:regions) { [region] }
+      end
+    end
+
+    let(:ec2s) {
+      {
+        "#{key_name}" => {
+          "#{region}" => instances.tap do |m|
+            allow(m).to receive(:instances) { m }
+          end
+        }
+      }
+    }
+
+    let(:instances) {
+      mock_instances.tap do |m|
+        allow(m).to receive(:filter) { m }
+      end
+    }
+
+    context 'with non-empty names' do
+      let(:mock_instances) {
+        [
+          double('instance', n: 1, tags: {'Name' => 'srvB' }),
+          double('instance', n: 2, tags: {'Name' => 'srvA' }),
+          double('instance', n: 3, tags: {'Name' => 'srvC' })
+        ]
+      }
+
+      it do
+        result = mock.instances(key_name)
+        expect(result.map {|ins| ins.n}).to match_array([2, 1, 3])
+      end
+    end
+
+    context 'with names including empty one' do
+      let(:mock_instances) {
+        [
+          double('instance', n: 1, tags: {'Name' => 'srvA'}),
+          double('instance', n: 2, tags: {}),
+          double('instance', n: 3, tags: {'Name' => 'srvC' })
+        ]
+      }
+
+      it do
+        result = mock.instances(key_name)
+        expect(result.map {|ins| ins.n}).to match_array([2, 1, 3])
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Hello @mirakui .

ec2ssh is an awesome tool. I use it all the time!
But, unfortunately, it seems that it couldn't handle a situation when I execute `ec2ssh update` and there are some EC2 instances that has no name.
I fixed it, so please check it!

![screenshot 2015-01-08 03 15 30_censored](https://cloud.githubusercontent.com/assets/7619736/5650793/f581af9a-96e4-11e4-99bb-ba28fa1753f1.jpg)


```error
$ ec2ssh update

/Library/Ruby/Gems/2.0.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:34:in `sort_by': comparison of NilClass with String failed (ArgumentError)
  from /Library/Ruby/Gems/2.0.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:34:in `block in instances'
  from /Library/Ruby/Gems/2.0.0/gems/ec2ssh-3.0.0/lib/ec2ssh/ec2_instances.rb:30:in `map'
  ...
```
