### PR TITLE
Add 'shellcomp' command: loading completion functions easily in bash/zsh

### DIFF
--- a/bash/ec2ssh.bash
+++ b/bash/ec2ssh.bash
@@ -1,0 +1,53 @@
+# bash completion support for ec2ssh
+
+_ec2ssh() {
+    local cmd cur prev subcmd
+    cmd=$1
+    cur=$2
+    prev=$3
+
+    subcmds="help init migrate remove update version"
+    common_opts="--dotfile --verbose"
+
+    # contextual completion
+    case $prev in
+        ec2ssh)
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W "$common_opts" $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -W "$subcmds" $cur) )
+            esac
+            return 0
+            ;;
+        --aws-key)
+            COMPREPLY=()
+            return 0;
+            ;;
+        --dotfile)
+            COMPREPLY=( $(compgen -o default -- "$cur"))
+            return 0;
+            ;;
+    esac
+
+    # complete options
+    subcmd=${COMP_WORDS[1]}
+
+    case $subcmd in
+        update)
+            COMPREPLY=( $(compgen -W "--aws-key $common_opts" -- "$cur") )
+            ;;
+        help)
+            COMPREPLY=( $(compgen -W "$subcmds" $cur) )
+            ;;
+        *)
+            COMPREPLY=( $(compgen -W "$common_opts" -- "$cur") )
+            ;;
+    esac
+
+    return 0
+
+}
+
+complete -F _ec2ssh ec2ssh

--- a/lib/ec2ssh/cli.rb
+++ b/lib/ec2ssh/cli.rb
@@ -51,6 +51,38 @@ module Ec2ssh
       command.run
     end
 
+    desc 'shellcomp [-]', 'Initialize shell completion for bash/zsh'
+    def shellcomp(_ = false)
+      if args.include?("-")
+        print_rc = true
+      else
+        print_rc = false
+      end
+
+      # print instructions for automatically enabling shell completion
+      unless print_rc
+        puts <<EOS
+# Enable ec2ssh completion by adding
+# the following to .bash_profile/.zshrc
+
+type ec2ssh >/dev/null 2>&1 && eval "$(ec2ssh shellcomp -)"
+
+EOS
+        exit(false)
+      end
+
+      # print shell script for enabling shell completion
+      zsh_comp_file = File.expand_path("../../../zsh/_ec2ssh", __FILE__)
+      bash_comp_file = File.expand_path("../../../bash/ec2ssh.bash", __FILE__)
+      puts <<EOS
+if [ -n "${BASH_VERSION:-}" ]; then
+    source #{bash_comp_file}
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    source #{zsh_comp_file}
+fi
+EOS
+    end
+
     desc 'version', 'Show version'
     def version
       require 'ec2ssh/version'


### PR DESCRIPTION
This patch adds 'shellcomp' command.

By this command, you can enable shell completion without copying `zsh/_ec2ssh` or `bash/ec2ssh.bash` by hand.

'shellcomp' works like `rbenv init`.  You can load completion function by adding following line to .bash_profile or .zshrc:

~~~
eval "$(ec2ssh shellcomp -)"
~~~

It automatically detect whether running shell is bash or zsh, and load appropriate script files which implements completion function.