### PR TITLE
complete aws key name in zsh completion

### DIFF
--- a/zsh/_ec2ssh
+++ b/zsh/_ec2ssh
@@ -25,7 +25,7 @@ _ec2ssh-update() {
 
     integer ret=1
     _arguments -C -S \
-               '--aws-key:aws key name' \
+               '--aws-key:aws key name:__ec2ssh_aws_keys' \
                '--dotfile:ec2ssh dotfile:_files' \
                '--verbose' && return
     return $ret
@@ -46,6 +46,30 @@ __ec2ssh_noarg_cmd() {
         '--dotfile:ec2ssh dotfile:_files' \
         '--verbose' && return
     return $ret
+}
+
+_ec2ssh-help() {
+    local curcontext context state line
+    declare -A opt_args
+
+    integer ret=1
+    _arguments -C -S \
+               '(-): :->commands' && return
+
+    case $state in
+        (commands)
+            _ec2ssh_commands && ret=0
+            ;;
+    esac
+
+    return $ret
+}
+
+
+__ec2ssh_aws_keys() {
+    local keys
+    keys=$(ruby -r ec2ssh/dsl -e 'puts Ec2ssh::Dsl::Parser.parse_file(File.expand_path(".ec2ssh", "~")).aws_keys.keys' 2> /dev/null)
+    _values 'aws key name' $(echo $keys)
 }
 
 _ec2ssh() {

--- a/zsh/_ec2ssh
+++ b/zsh/_ec2ssh
@@ -67,8 +67,15 @@ _ec2ssh-help() {
 
 
 __ec2ssh_aws_keys() {
-    local keys
-    keys=$(ruby -r ec2ssh/dsl -e 'puts Ec2ssh::Dsl::Parser.parse_file(File.expand_path(".ec2ssh", "~")).aws_keys.keys' 2> /dev/null)
+    local keys dotfile
+
+    if (( ind = ${words[(I)--dotfile]} )) && [ -f "${~words[ind+1]}" ]; then
+        dotfile=${~words[ind+1]}
+    else
+        dotfile="$HOME/.ec2ssh"
+    fi
+
+    keys=$(echo "$dotfile" | ruby -r ec2ssh/dsl -e 'puts Ec2ssh::Dsl::Parser.parse_file(STDIN.read.strip).aws_keys.keys' 2> /dev/null)
     _values 'aws key name' $(echo $keys)
 }
 


### PR DESCRIPTION
This patch implements zsh completion for `--aws-key` option.

Internally it parses `~/.ec2ssh` (or another file specified by preceding `--dotfile`) by calling `Ec2ssh::Dsl::Parser.parse_file`. 