### PR TITLE
Use "%-" for ERB's trim_mode

### DIFF
--- a/lib/ec2ssh/builder.rb
+++ b/lib/ec2ssh/builder.rb
@@ -6,7 +6,9 @@ module Ec2ssh
   class Builder
     def initialize(container)
       @container = container
-      @host_lines_erb = ERB.new @container.host_line
+      safe_level = nil
+      erb_trim_mode = '%-'
+      @host_lines_erb = ERB.new @container.host_line, safe_level, erb_trim_mode
     end
 
     def build_host_lines
@@ -16,10 +18,11 @@ module Ec2ssh
         ec2s.instances(name).each do |instance|
           bind = instance.instance_eval { binding }
           next if @container.reject && @container.reject.call(instance)
-          out.puts @host_lines_erb.result(bind)
+          line = @host_lines_erb.result(bind).rstrip
+          out.puts line unless line.empty?
         end
       end
-      out.string
+      out.string.rstrip
     end
 
     def ec2s

--- a/spec/lib/ec2ssh/builder_spec.rb
+++ b/spec/lib/ec2ssh/builder_spec.rb
@@ -38,7 +38,7 @@ describe Ec2ssh::Builder do
     end
 
     it do
-      expect(builder.build_host_lines).to eq <<-END
+      expect(builder.build_host_lines).to eq <<-END.rstrip
 # section: key1
 Host srv1
 Host srv2
@@ -54,12 +54,34 @@ Host srv4
       end
 
       it do
-        expect(builder.build_host_lines).to eq <<-END
+        expect(builder.build_host_lines).to eq <<-END.rstrip
 # section: key1
 Host srv2
 # section: key2
 Host srv3
 Host srv4
+        END
+      end
+    end
+
+    context 'checking erb trim_mode' do
+      before do
+        container.host_line = <<-END
+% if tags['Name']
+  <%- if tags['Name'] == 'srv3' -%>
+Host <%= tags['Name'] %>
+  HostName <%= tags['Name'] %>
+  <%- end -%>
+% end
+        END
+      end
+
+      it do
+        expect(builder.build_host_lines).to eq <<-END.rstrip
+# section: key1
+# section: key2
+Host srv3
+  HostName srv3
         END
       end
     end

--- a/spec/lib/ec2ssh/command/update_spec.rb
+++ b/spec/lib/ec2ssh/command/update_spec.rb
@@ -86,7 +86,6 @@ Host srv1
   HostName 10.0.0.1
 Host srv2
   HostName 10.0.0.2
-
 ### EC2SSH END ###
 
 # after lines...

--- a/spec/lib/ec2ssh/dsl_spec.rb
+++ b/spec/lib/ec2ssh/dsl_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 require 'ec2ssh/dsl'
 
 describe Ec2ssh::Dsl do
-  shared_examples 'a filled dsl container' do
-  end
-
   let(:dsl_str) do
 <<-END
 aws_keys(


### PR DESCRIPTION
See: http://docs.ruby-lang.org/en/2.2.0/ERB.html

`%-` means:
- `%`  enables Ruby code processing for lines beginning with `%`
- `-` omit blank lines ending in `-%>`
