### PR TITLE
require ruby >= 2.0.0

### DIFF
--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/mirakui/ec2ssh"
   s.summary     = %q{A ssh_config manager for AWS EC2}
   s.description = %q{ec2ssh is a ssh_config manager for AWS EC2}
+  s.required_ruby_version = ">= 2.0.0"
 
   s.rubyforge_project = "ec2ssh"
   s.add_dependency "thor", "~> 0.14"


### PR DESCRIPTION
Explicitly requiring ruby 2.0.0 or later is convenient for users.

With `required_ruby_version` in gemspec, 1.9.x users will get an error like:

~~~
ERROR:  Error installing pkg/ec2ssh-3.0.3.gem:
        ec2ssh requires Ruby version >= 2.0.0.
~~~

which is informative and urges users to migrate to newer ruby.

On the other hand, without `required_ruby_version`, users will get messy error messages:

~~~
em install ec2ssh
Fetching: ec2ssh-3.0.3.gem (100%)
Fetching: aws-sdk-v1-1.63.0.gem (100%)
Successfully installed ec2ssh-3.0.3
Successfully installed aws-sdk-v1-1.63.0
2 gems installed
Installing ri documentation for ec2ssh-3.0.3...

RDoc::Parser::Ruby failure around line 31 of
lib/ec2ssh/dsl.rb

Before reporting this, could you check that the file you're documenting
has proper syntax:

  /Users/haya/.rbenv/versions/1.9.3-p545/bin/ruby -c lib/ec2ssh/dsl.rb

RDoc is not a full Ruby parser and will fail when fed invalid ruby programs.

The internal error was:

        (RDoc::Error) unknown type of %string "i"

ERROR:  While generating documentation for ec2ssh-3.0.3
... MESSAGE:   unknown type of %string "i"
... RDOC args: --ri --op /Users/haya/.rbenv/versions/1.9.3-p545/lib/ruby/gems/1.9.1/doc/ec2ssh-3.0.3/ri lib --title ec2ssh-3.0.3 Documentation --quiet
~~~