### PR TITLE
Revive path option for changing ssh config path

### DIFF
--- a/lib/ec2ssh/cli.rb
+++ b/lib/ec2ssh/cli.rb
@@ -6,6 +6,7 @@ require 'ec2ssh/migrator'
 
 module Ec2ssh
   class CLI < Thor
+    class_option :path, banner: "/path/to/ssh_config"
     class_option :dotfile, banner: '$HOME/.ec2ssh', default: "#{ENV['HOME']}/.ec2ssh"
     class_option :verbose, banner: 'enable debug log', default: false
 


### PR DESCRIPTION
In https://github.com/mirakui/ec2ssh/commit/24e8e75fa74d07efd0365b35a94fd5fe13cdc547#diff-3430d34610c7158a72529f45dc292641L10, path option was removed.
However, In master at [here](https://github.com/mirakui/ec2ssh/blob/5bf15da9004423a8a0d3a5b27da9fac154be966c/lib/ec2ssh/command.rb#L17), path option still used, and this option should be usable for changing the ssh config path.

