### PR TITLE
[WIP]Use aws-sdk-v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - 2.3.0
   - ruby-head
 script: 'bundle exec rspec spec'
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v 1.13.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - ruby-head
 script: 'bundle exec rspec spec'
 before_install: gem install bundler -v 1.13.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 gemspec
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.2.0')
+  gem "listen", "2.10.1"
+end
 gem 'rspec', '~> 3.0'
 gem 'rspec-its', '~> 1.0'
 gem 'guard-rspec', '~> 4.3'

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ $ vi ~/.ec2ssh
 profiles 'default', 'myprofile'
 regions 'us-east-1'
 
-# Ignore unnamed instances
-reject {|instance| !instance.tags['Name'] }
+# Ignore instances
+reject {|instance| instance.tags.find{|t| t.key == 'Name' }.value == 'outdated-instance' }
 
-# You can use methods of AWS::EC2::Instance.
-# See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html
+# You can use methods of Aws::EC2::Instance.
+# See http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html
 host_line <<END
-Host <%= tags['Name'] %>.<%= availability_zone %>
-  HostName <%= dns_name || private_ip_address %>
+Host <%= tags.find{|t| t.key == 'Name' }.value %>.<%= placement.availability_zone %>
+  HostName <%= public_dns_name.empty? private_ip_address : public_dns_name %>
 END
 ```
 

--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "ec2ssh"
   s.add_dependency "thor", "~> 0.14"
   s.add_dependency "highline", "~> 1.6"
-  s.add_dependency 'aws-sdk', '~> 1.8'
+  s.add_dependency 'aws-sdk', '~> 2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/ec2ssh/builder.rb
+++ b/lib/ec2ssh/builder.rb
@@ -26,7 +26,7 @@ module Ec2ssh
     end
 
     def ec2s
-      @ec2s ||= Ec2Instances.new aws_keys, @container.regions
+      @ec2s ||= Ec2Instances.new @container.regions, @container.profiles
     end
 
     def aws_keys

--- a/lib/ec2ssh/builder.rb
+++ b/lib/ec2ssh/builder.rb
@@ -13,9 +13,9 @@ module Ec2ssh
 
     def build_host_lines
       out = StringIO.new
-      aws_keys.each do |name, key|
-        out.puts "# section: #{name}"
-        ec2s.instances(name).each do |instance|
+      @container.profiles.each do |profile|
+        out.puts "# section: #{profile}"
+        ec2s.instances(profile).each do |instance|
           bind = instance.instance_eval { binding }
           next if @container.reject && @container.reject.call(instance)
           line = @host_lines_erb.result(bind).rstrip

--- a/lib/ec2ssh/builder.rb
+++ b/lib/ec2ssh/builder.rb
@@ -29,16 +29,5 @@ module Ec2ssh
       @ec2s ||= Ec2Instances.new @container.regions, @container.profiles
     end
 
-    def aws_keys
-      @aws_keys ||= if @container.profiles
-                      keys = {}
-                      @container.profiles.each do |profile_name|
-                        keys[profile_name] = Ec2Instances.expand_profile_name_to_credential profile_name
-                      end
-                      keys
-                    else
-                      @container.aws_keys
-                    end
-    end
   end
 end

--- a/lib/ec2ssh/dsl.rb
+++ b/lib/ec2ssh/dsl.rb
@@ -33,7 +33,6 @@ module Ec2ssh
     end
 
     class Container < Struct.new(*%i[
-      aws_keys
       profiles
       regions
       host_line

--- a/lib/ec2ssh/dsl.rb
+++ b/lib/ec2ssh/dsl.rb
@@ -56,9 +56,6 @@ module Ec2ssh
       end
 
       def self.validate(result)
-        if result.aws_keys && result.profiles
-          raise DotfileValidationError, "`aws_keys` and `profiles` doesn't work together in dotfile."
-        end
       end
     end
   end

--- a/lib/ec2ssh/dsl.rb
+++ b/lib/ec2ssh/dsl.rb
@@ -33,6 +33,7 @@ module Ec2ssh
     end
 
     class Container < Struct.new(*%i[
+      aws_keys
       profiles
       regions
       host_line

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-v1'
+require 'aws-sdk'
 
 module Ec2ssh
   class Ec2Instances

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -2,11 +2,11 @@ require 'aws-sdk'
 
 module Ec2ssh
   class Ec2Instances
-    attr_reader :ec2s, :aws_keys
+    attr_reader :ec2s
 
-    def initialize(aws_keys, regions)
-      @aws_keys = aws_keys
+    def initialize(regions, profiles)
       @regions = regions
+      @profiles = profiles
     end
 
     def make_ec2s

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -42,9 +42,5 @@ module Ec2ssh
       }.flatten
     end
 
-    def self.expand_profile_name_to_credential(profile_name)
-      provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(profile_name: profile_name)
-      provider.credentials
-    end
   end
 end

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -27,19 +27,21 @@ module Ec2ssh
     end
 
     def instances(profile)
-      @regions.map {|region|
+      fetch_instances(profile).sort_by do |ins|
+        ins.tags.find_all do |tag|
+          tag.key == 'Name'
+        end.to_s
+      end
+    end
+
+    def fetch_instances(profile)
+      @regions.map do |region|
         ec2s[profile][region].instances(
           filters: [{
             name:   'instance-state-name',
             values:  %w(running)
-          }]).
-          to_a.
-          sort_by do |ins|
-            ins.tags.find_all do |tag|
-              tag.key == 'Name'
-            end.to_s
-          end
-      }.flatten
+        }]).to_a
+      end.flatten
     end
 
   end

--- a/spec/lib/ec2ssh/dsl_spec.rb
+++ b/spec/lib/ec2ssh/dsl_spec.rb
@@ -16,59 +16,9 @@ END
     subject(:result) { Ec2ssh::Dsl::Parser.parse dsl_str }
 
     its(:profiles) { should == ['default', 'myprofile'] }
-    its(:aws_keys) { should be_nil }
     its(:regions) { should == ['ap-northeast-1', 'us-east-1'] }
     its(:host_line) { should == 'host lines' }
     it { expect(result.reject.call(123)).to eq(123) }
     its(:path) { should == 'path' }
-  end
-
-  context 'with aws_keys' do
-    let(:dsl_str) do
-<<-END
-aws_keys(
-  key1: { access_key_id: 'ACCESS_KEY1', secret_access_key: 'SECRET1' },
-  key2: { access_key_id: 'ACCESS_KEY2', secret_access_key: 'SECRET2' }
-)
-regions 'ap-northeast-1', 'us-east-1'
-host_line 'host lines'
-reject {|instance| instance }
-path 'path'
-END
-    end
-
-    subject(:result) { Ec2ssh::Dsl::Parser.parse dsl_str }
-
-    its(:profiles) { should be_nil }
-    its(:aws_keys) do
-      should == {
-        key1: { access_key_id: 'ACCESS_KEY1', secret_access_key: 'SECRET1' },
-        key2: { access_key_id: 'ACCESS_KEY2', secret_access_key: 'SECRET2' }
-      }
-    end
-    its(:regions) { should == ['ap-northeast-1', 'us-east-1'] }
-    its(:host_line) { should == 'host lines' }
-    it { expect(result.reject.call(123)).to eq(123) }
-    its(:path) { should == 'path' }
-  end
-
-  context 'with profiles and aws_keys both' do
-    let(:dsl_str) do
-<<-END
-aws_keys(
-  key1: { access_key_id: 'ACCESS_KEY1', secret_access_key: 'SECRET1' },
-  key2: { access_key_id: 'ACCESS_KEY2', secret_access_key: 'SECRET2' }
-)
-profiles 'default', 'myprofile'
-regions 'ap-northeast-1', 'us-east-1'
-host_line 'host lines'
-reject {|instance| instance }
-path 'path'
-END
-    end
-
-    it do
-      expect { Ec2ssh::Dsl::Parser.parse dsl_str }.to raise_error Ec2ssh::DotfileValidationError
-    end
   end
 end

--- a/spec/lib/ec2ssh/ec2_instances_spec.rb
+++ b/spec/lib/ec2ssh/ec2_instances_spec.rb
@@ -12,34 +12,18 @@ describe Ec2ssh::Ec2Instances do
     }
 
     let(:mock) do
-      described_class.new(profiles=profile, regions=[region]).tap do |e|
-        allow(e).to receive(:ec2s) { ec2s }
+      described_class.new(profiles=[profile], regions=[region]).tap do |e|
+        allow(e).to receive(:fetch_instances).with(profile).and_return(mock_instances)
         allow(e).to receive(:regions) { [region] }
       end
     end
 
-    let(:ec2s) {
-      {
-        "#{profile}" => {
-          "#{region}" => instances.tap do |m|
-            allow(m).to receive(:instances) { m }
-          end
-        }
-      }
-    }
-
-    let(:instances) {
-      mock_instances.tap do |m|
-        allow(m).to receive(:filter) { m }
-      end
-    }
-
     context 'with non-empty names' do
       let(:mock_instances) {
         [
-          double('instance', n: 1, tags: { key: 'Name', value: 'srvB' }),
-          double('instance', n: 2, tags: { key: 'Name', value: 'srvA' }),
-          double('instance', n: 3, tags: { key: 'Name', value: 'srvC' })
+          double('instance', n: 1, tags: [double('tag', key: 'Name', value: 'srvB')]),
+          double('instance', n: 2, tags: [double('tag', key: 'Name', value: 'srvA')]),
+          double('instance', n: 3, tags: [double('tag', key: 'Name', value: 'srvC')])
         ]
       }
 
@@ -52,9 +36,9 @@ describe Ec2ssh::Ec2Instances do
     context 'with names including empty one' do
       let(:mock_instances) {
         [
-          double('instance', n: 1, tags: { key: 'Name', value: 'srvA'}),
-          double('instance', n: 2, tags: {}),
-          double('instance', n: 3, tags: { key: 'Name', value: 'srvC' })
+          double('instance', n: 1, tags: [double('tag', key: 'Name', value: 'srvA')]),
+          double('instance', n: 2, tags: [double('tag', key: 'Name', value: nil   )]),
+          double('instance', n: 3, tags: [double('tag', key: 'Name', value: 'srvC')])
         ]
       }
 

--- a/spec/lib/ec2ssh/ec2_instances_spec.rb
+++ b/spec/lib/ec2ssh/ec2_instances_spec.rb
@@ -3,8 +3,8 @@ require 'ec2ssh/ec2_instances'
 
 describe Ec2ssh::Ec2Instances do
   describe '#instances' do
-    let(:key_name) {
-      "dummy_key_name"
+    let(:profile) {
+      "default"
     }
 
     let(:region) {
@@ -12,7 +12,7 @@ describe Ec2ssh::Ec2Instances do
     }
 
     let(:mock) do
-      described_class.new(profiles='', regions=[region]).tap do |e|
+      described_class.new(profiles=profile, regions=[region]).tap do |e|
         allow(e).to receive(:ec2s) { ec2s }
         allow(e).to receive(:regions) { [region] }
       end
@@ -20,7 +20,7 @@ describe Ec2ssh::Ec2Instances do
 
     let(:ec2s) {
       {
-        "#{key_name}" => {
+        "#{profile}" => {
           "#{region}" => instances.tap do |m|
             allow(m).to receive(:instances) { m }
           end
@@ -37,14 +37,14 @@ describe Ec2ssh::Ec2Instances do
     context 'with non-empty names' do
       let(:mock_instances) {
         [
-          double('instance', n: 1, tags: {'Name' => 'srvB' }),
-          double('instance', n: 2, tags: {'Name' => 'srvA' }),
-          double('instance', n: 3, tags: {'Name' => 'srvC' })
+          double('instance', n: 1, tags: { key: 'Name', value: 'srvB' }),
+          double('instance', n: 2, tags: { key: 'Name', value: 'srvA' }),
+          double('instance', n: 3, tags: { key: 'Name', value: 'srvC' })
         ]
       }
 
       it do
-        result = mock.instances(key_name)
+        result = mock.instances(profile)
         expect(result.map {|ins| ins.n}).to match_array([2, 1, 3])
       end
     end
@@ -52,14 +52,14 @@ describe Ec2ssh::Ec2Instances do
     context 'with names including empty one' do
       let(:mock_instances) {
         [
-          double('instance', n: 1, tags: {'Name' => 'srvA'}),
+          double('instance', n: 1, tags: { key: 'Name', value: 'srvA'}),
           double('instance', n: 2, tags: {}),
-          double('instance', n: 3, tags: {'Name' => 'srvC' })
+          double('instance', n: 3, tags: { key: 'Name', value: 'srvC' })
         ]
       }
 
       it do
-        result = mock.instances(key_name)
+        result = mock.instances(profile)
         expect(result.map {|ins| ins.n}).to match_array([2, 1, 3])
       end
     end


### PR DESCRIPTION
⚠️ __This commits are including breaking changes!__ ⚠️ 

aws-sdk v1 is outdated gem.
So, I change ec2ssh to use aws-sdk v2 .

If release ec2ssh after mergeing this commits, please increment gem major version. 🙏 

## works
- update aws-sdk to version 2
- remove outdated option 'aws_keys'
- rewrite specs
- drop support of eol ruby(2.0)
- update ruby version to use run specs on travis ci
- update readme
- and so on... :relieved:
