### PR TITLE
Add filters option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/

--- a/lib/ec2ssh/builder.rb
+++ b/lib/ec2ssh/builder.rb
@@ -26,7 +26,7 @@ module Ec2ssh
     end
 
     def ec2s
-      @ec2s ||= Ec2Instances.new aws_keys, @container.regions
+      @ec2s ||= Ec2Instances.new aws_keys, @container
     end
 
     def aws_keys

--- a/lib/ec2ssh/dsl.rb
+++ b/lib/ec2ssh/dsl.rb
@@ -28,6 +28,10 @@ module Ec2ssh
       @_result.reject = block
     end
 
+    def filters(filters)
+      @_result.filters = filters
+    end
+
     def path(str)
       @_result.path = str
     end
@@ -38,6 +42,7 @@ module Ec2ssh
       regions
       host_line
       reject
+      filters
       path
     ])
     end

--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -4,9 +4,10 @@ module Ec2ssh
   class Ec2Instances
     attr_reader :ec2s, :aws_keys
 
-    def initialize(aws_keys, regions)
+    def initialize(aws_keys, container)
       @aws_keys = aws_keys
-      @regions = regions
+      @container = container
+      @regions = @container.regions
     end
 
     def make_ec2s
@@ -28,10 +29,16 @@ module Ec2ssh
 
     def instances(key_name)
       @regions.map {|region|
-        ec2s[key_name][region].instances.
-          filter('instance-state-name', 'running').
-          to_a.
-          sort_by {|ins| ins.tags['Name'].to_s }
+
+        instances = ec2s[key_name][region].instances
+        if @container.filters
+          @container.filters.each do |filter|
+            instances.filter(filter['key'], filter['value'])
+          end
+        else
+          instances.filter('instance-state-name', 'running')
+        end
+        instances.to_a.sort_by {|ins| ins.tags['Name'].to_s }
       }.flatten
     end
 

--- a/spec/aws_sdk_compatibility_spec.rb
+++ b/spec/aws_sdk_compatibility_spec.rb
@@ -5,11 +5,17 @@ describe 'aws-sdk compatibility' do
   let(:region) { 'us-west-1' }
   let(:root_device) { '/dev/xvda' }
 
+  let(:container) do
+    Ec2ssh::Dsl::Container.new.tap do |c|
+      c.regions = ['us-west-1']
+    end
+  end
+
   let!(:ec2_instances) do
     VCR.use_cassette('ec2-instances') do
       Ec2ssh::Ec2Instances.new(
         {'foo' => {access_key_id: '', secret_access_key: ''}},
-        ['us-west-1']
+        container,
       ).instances('foo')
     end
   end

--- a/spec/lib/ec2ssh/ec2_instances_spec.rb
+++ b/spec/lib/ec2ssh/ec2_instances_spec.rb
@@ -11,8 +11,14 @@ describe Ec2ssh::Ec2Instances do
       "ap-northeast-1"
     }
 
+    let(:container) do
+      Ec2ssh::Dsl::Container.new.tap do |c|
+        c.regions = [region]
+      end
+    end
+
     let(:mock) do
-      described_class.new(profiles='', regions=[region]).tap do |e|
+      described_class.new(profiles='', container).tap do |e|
         allow(e).to receive(:ec2s) { ec2s }
         allow(e).to receive(:regions) { [region] }
       end


### PR DESCRIPTION
# 概要
* EC2のインスタンス検索を設定できるように `filters` オプションを実装
* filetrsを指定しない場合、 `instance-state-name: running` を使用する

設定例：
```
filters([
  {
    key: 'instance-state-name',
    value: 'running'
  },
  {
    key: 'instance-state-name',
    value: 'stopped'
  }
])
```

## なぜこの機能が必要か
* EC2にSSHする方法がSSMやMSSHの登場でPublic IP/DNSに限らなくなった
* SSM / MSSH はInstanceID を指定して接続するので`stopped`インスタンスを含めて生成したほうが起動 / 停止を繰り返しても再実行する必要がないので効率的

----

# About
* Add `filters` option for EC2 instance filter.
* If `filters` option does not exist, use `instance-state-name: running`.

Example: 
```
filters([
  {
    key: 'instance-state-name',
    value: 'running'
  },
  {
    key: 'instance-state-name',
    value: 'stopped'
  }
])
```

## Why do I need this
* SSM and MSSH were released, so no longer limited to Public IP or DNS
* Generate config include `stopped` instances is efficiency because SSM and MSSH use InstanceID for a new session. 
