### PR TITLE
Fix missing `require` call

### DIFF
--- a/lib/ec2ssh/ec2_instances.rb
+++ b/lib/ec2ssh/ec2_instances.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk'
+require 'ec2ssh/exceptions'
 
 module Ec2ssh
   class Ec2Instances


### PR DESCRIPTION
`bundle exec rspec spec/lib/ec2ssh/ec2_instances_spec.rb` is failed with `NameError: uninitialized constant Ec2ssh::DotfileValidationError`.
Because `DotfileValidationError` is now used in `lib/ec2ssh/ec2_instances.rb` since b52a54da5e207176c6eb82cf2adbf795688be0cf, but `require` call is missing.