### PR TITLE
Delete `rubyforge_project=` in gemspec

### DIFF
--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = %q{ec2ssh is a ssh_config manager for AWS EC2}
   s.required_ruby_version = ">= 2.2.0"
 
-  s.rubyforge_project = "ec2ssh"
   s.add_dependency "thor", ">= 0.14", "< 2.0"
   s.add_dependency "highline", ">= 1.6", "< 3.0"
   s.add_dependency "aws-sdk", "~> 2"


### PR DESCRIPTION
RubyForge was sunsetted in 2013.
ref. https://github.com/rubygems/rubygems/pull/2436