### PR TITLE
Remove `--aws-key` option and add `--path` option in shellcomp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Remove `--aws-key` option and add `--path` option in shellcomp (#56)
 * Use aws-sdk v3 and stop using v2 (#54)
 * Delete `rubyforge_project=` in gemspec (#51)
 * Relax thor and highline versions (#49)

--- a/bash/ec2ssh.bash
+++ b/bash/ec2ssh.bash
@@ -7,7 +7,7 @@ _ec2ssh() {
     prev=$3
 
     subcmds="help init remove update version"
-    common_opts="--dotfile --verbose"
+    common_opts="--path --dotfile --verbose"
 
     # contextual completion
     case $prev in
@@ -21,11 +21,7 @@ _ec2ssh() {
             esac
             return 0
             ;;
-        --aws-key)
-            COMPREPLY=()
-            return 0;
-            ;;
-        --dotfile)
+        --path | --dotfile)
             COMPREPLY=( $(compgen -o default -- "$cur"))
             return 0;
             ;;
@@ -35,9 +31,6 @@ _ec2ssh() {
     subcmd=${COMP_WORDS[1]}
 
     case $subcmd in
-        update)
-            COMPREPLY=( $(compgen -W "--aws-key $common_opts" -- "$cur") )
-            ;;
         help)
             COMPREPLY=( $(compgen -W "$subcmds" $cur) )
             ;;

--- a/zsh/_ec2ssh
+++ b/zsh/_ec2ssh
@@ -3,40 +3,35 @@
 # main completion function
 _ec2ssh-init() {
     local ret
-    _call_function ret __ec2ssh_noarg_cmd
+    _call_function ret __ec2ssh_common_cmd
     return $ret
 }
 
 _ec2ssh-remove() {
     local ret
-    _call_function ret __ec2ssh_noarg_cmd
+    _call_function ret __ec2ssh_common_cmd
     return $ret
 }
 
 _ec2ssh-update() {
-    local curcontext context state line
-    declare -A opt_args
-
-    integer ret=1
-    _arguments -C -S \
-               '--aws-key:aws key name' \
-               '--dotfile:ec2ssh dotfile:_files' \
-               '--verbose' && return
+    local ret
+    _call_function ret __ec2ssh_common_cmd
     return $ret
 }
 
 _ec2ssh-version() {
     local ret
-    _call_function ret __ec2ssh_noarg_cmd
+    _call_function ret __ec2ssh_common_cmd
     return $ret
 }
 
-__ec2ssh_noarg_cmd() {
+__ec2ssh_common_cmd() {
     local curcontext context state line
     declare -A opt_args
 
     integer ret=1
     _arguments -C -S \
+        '--path:ssh_config file:_files' \
         '--dotfile:ec2ssh dotfile:_files' \
         '--verbose' && return
     return $ret
@@ -49,6 +44,7 @@ _ec2ssh() {
     integer ret=1
 
     _arguments -C -S \
+        '--path:ssh_config file:_files' \
         '--dotfile:ec2ssh dotfile:_files' \
         '--verbose' \
         '(-): :->commands' \


### PR DESCRIPTION
Fix #53 

* Remove outdated `--aws-key` option in shellcomp
* Support `--path` option in shellcomp