### PR TITLE
Drop support of outdated Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.summary     = %q{A ssh_config manager for AWS EC2}
   s.description = %q{ec2ssh is a ssh_config manager for AWS EC2}
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "thor", ">= 0.14", "< 2.0"
   s.add_dependency "highline", ">= 1.6", "< 3.0"


### PR DESCRIPTION
[Support of Ruby 2.4 has ended](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/)