### PR TITLE
Drop support for thor gem < v1.2

### DIFF
--- a/ec2ssh.gemspec
+++ b/ec2ssh.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = %q{ec2ssh is a ssh_config manager for AWS EC2}
   s.required_ruby_version = ">= 2.6.0"
 
-  s.add_dependency "thor", ">= 0.14", "< 2.0"
+  s.add_dependency "thor", ">= 1.2", "< 2.0"
   s.add_dependency "highline", ">= 1.6", "< 3.0"
   s.add_dependency "aws-sdk-core", "~> 3"
   s.add_dependency "aws-sdk-ec2", "~> 1"


### PR DESCRIPTION
For better compatilibity with Ruby 3.1.
Fix deprecation warning of `DidYouMean::SPELL_CHECKERS.merge!` when using thor < v1.2 in Ruby 3.1.

ref. rails/thor#761