### PR TITLE
Fix deprecation warning of thor

### DIFF
--- a/lib/ec2ssh/cli.rb
+++ b/lib/ec2ssh/cli.rb
@@ -114,5 +114,9 @@ EOS
         end
       end
     end
+
+    def self.exit_on_failure?
+      false
+    end
   end
 end


### PR DESCRIPTION
I think `exit_on_failure?` should return `true`. But it is breaking change. So, I only fixed deprecation warning in this PR.

```
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `Ec2ssh::CLI`
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
```

ref. rails/thor#625